### PR TITLE
Add kitchen and night cleaning toggles with day-of-week display

### DIFF
--- a/src/views/DetailsPage.vue
+++ b/src/views/DetailsPage.vue
@@ -18,7 +18,7 @@
       <ion-list>
         <ion-item v-for="item in mainExcel.items">
           <ion-label @click="openModal(item)">
-            {{ item.date }} ({{ item.room }})
+            {{ item.date }} - {{ getDayOfWeek(item.date) }} ({{ item.room }})
             {{ item.description }}
             {{ item.amount != "" ? "$" + item.amount : "" }}
           </ion-label>
@@ -167,6 +167,13 @@ const itemExcel = store.state.itemExcel;
 //const { setItem } = mapMutations("itemExcel", ["setItem"]);
 const mainExcel = store.state.mainExcel;
 const totalAmount = computed(() => store.getters.getTotalAmount);
+
+// Función para obtener el día de la semana en inglés
+const getDayOfWeek = (dateString) => {
+  const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+  const date = new Date(dateString);
+  return days[date.getDay()];
+};
 const isOpen = ref(false);
 const isOpenConfirm = ref(false);
 const modal = ref();


### PR DESCRIPTION
  - Add individual toggles for Kitchen cleaning and Night cleaning selection in home page
  - Implement localStorage persistence for cleaning type selections across sessions
  - Add validation requiring at least one cleaning type to be selected
  - Configure Night cleaning as default selected option
  - Add reactive recalculation when toggle selections change
  - Display day of week (in English) after date in details page item list
  - Fix Night cleaning schedule to Monday-Thursday (was Monday-Friday)
  - Remove unused import for getWeekdaysMondayToFriday